### PR TITLE
Investigate doodle score posting issue

### DIFF
--- a/doodle/doodleJump.js
+++ b/doodle/doodleJump.js
@@ -362,12 +362,12 @@ function handleRestartClick(event) {
 
 function saveScore(score) {
     const xhr = new XMLHttpRequest();
-    xhr.open("POST", "processScores.php", true);
+    xhr.open("POST", "/login/processes/processScores.php", true);
     xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
     xhr.onreadystatechange = function() {
         if (xhr.readyState === 4 && xhr.status === 200) {
             console.log("Score saved successfully: " + score);
         }
     };
-    xhr.send("game=doodleJump&score=" + score + "&username=" + encodeURIComponent(localStorage.getItem('username')));
+    xhr.send("game=doodleJump&score=" + encodeURIComponent(score));
 }

--- a/doodle/doodleJump.php
+++ b/doodle/doodleJump.php
@@ -1,48 +1,59 @@
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-</head>
-<body>
-    <canvas  width="670px" height="670px" style="background-color: lightblue;"></canvas>
-    
+<?php
+session_start();
 
-    <div style ="float:right; margin-right: 40px; margin-top: 20px;">
-        <h1>Score</h1>
-        <table style = "border-color: black; border-style: solid; border-width: 3px;">
-            <tr><th>Player</th><th>Score</th><th>Time</th></tr>
-            
-            <?php
-            echo "You are Logged in as ".$_SESSION['username'];
-            ?>
-        </table>
-
-
-        <script src="doodleJump.js" defer></script>
-
-         <?php
-         session_start(); 
- if($_SERVER['HTTP_HOST'] == "127.0.0.1") {
+if($_SERVER['HTTP_HOST'] == "127.0.0.1") {
     $mysqli = new mysqli("localhost", "root", "", "mca");
 } else {
     $mysqli = new mysqli("195.35.59.14", "u121755072_adu", "fH:=aeo*l^D2", "u121755072_adudb");
 }
 if ($mysqli->connect_error) {
     die("Connection failed: " . $mysqli->connect_error);
-    exit;
 }
 
-
-$result = $mysqli -> query($sql);
-$rows = $result -> fetch_all(MYSQLI_ASSOC);
-
-foreach($rows as $row){
-    print("<tr><td>".$row["userid"]."</td><td>".$row["score"]."</td><td>".$row["timestamp"]."</td></tr>");
+$scoreRows = [];
+$sql = "SELECT u.username AS username, s.score AS score, s.timestamp AS timestamp
+        FROM scores s
+        JOIN users u ON s.id = u.id
+        WHERE s.game = 'doodleJump'
+        ORDER BY s.score DESC, s.timestamp ASC
+        LIMIT 20";
+if ($result = $mysqli->query($sql)) {
+    $scoreRows = $result->fetch_all(MYSQLI_ASSOC);
+    $result->free();
 }
-
-
 ?>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Doodle Jump</title>
+</head>
+<body>
+    <canvas width="670px" height="670px" style="background-color: lightblue;"></canvas>
+
+    <div style="float:right; margin-right: 40px; margin-top: 20px;">
+        <h1>Score</h1>
+        <div>
+            <?php
+            if (isset($_SESSION['UserID']) && $_SESSION['UserID'] !== '') {
+                echo "You are Logged in as " . htmlspecialchars($_SESSION['UserID']);
+            } else {
+                echo "Not logged in";
+            }
+            ?>
+        </div>
+        <table style="border-color: black; border-style: solid; border-width: 3px;">
+            <tr><th>Player</th><th>Score</th><th>Time</th></tr>
+            <?php foreach ($scoreRows as $row) { ?>
+                <tr>
+                    <td><?php echo htmlspecialchars($row['username']); ?></td>
+                    <td><?php echo htmlspecialchars($row['score']); ?></td>
+                    <td><?php echo htmlspecialchars($row['timestamp']); ?></td>
+                </tr>
+            <?php } ?>
+        </table>
     </div>
+
+    <script src="doodleJump.js" defer></script>
 </body>
 </html>

--- a/login/processes/processScores.php
+++ b/login/processes/processScores.php
@@ -8,23 +8,25 @@ if($_SERVER['HTTP_HOST'] == "127.0.0.1") {
     $mysqli = new mysqli("195.35.59.14", "u121755072_adu", "fH:=aeo*l^D2", "u121755072_adudb");
 }
 if ($mysqli->connect_error) {
-    die("Connection failed: " . $mysqli->connect_error);
+    http_response_code(500);
+    echo "DB connection failed";
     exit;
 }
 
-$uname = $_POST["username"];
-$uscore = $_POST["score"];
-$game = $_POST["game"];
+$uname = isset($_SESSION["UserID"]) ? $_SESSION["UserID"] : '';
+$uscore = isset($_POST["score"]) ? intval($_POST["score"]) : 0;
+$game = isset($_POST["game"]) ? $_POST["game"] : '';
 
-$sql = "insert into scores (game, id, score, timestamp) 
-values (
-('{$game}', (select id from users where username ='{$uname}'), {$uscore}, now())
-);";
-
-if($uname != "")
-{
-    $result = $mysqli->query($sql);
+if ($uname !== '' && $game !== '' && $uscore >= 0) {
+    $sql = "INSERT INTO scores (game, id, score, timestamp) VALUES (?, (SELECT id FROM users WHERE username = ?), ?, NOW())";
+    if ($stmt = $mysqli->prepare($sql)) {
+        $stmt->bind_param('ssi', $game, $uname, $uscore);
+        $stmt->execute();
+        $stmt->close();
+    }
 }
+
+echo "OK";
 
 ?>
 


### PR DESCRIPTION
Refactor Doodle Jump score submission and scoreboard display to ensure scores are correctly saved and shown.

The previous implementation suffered from an incorrect client-side POST URL, reliance on an unreliable `localStorage` username, and a server-side script with SQL injection vulnerabilities and incorrect session/database handling, preventing scores from being saved and displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-29524275-3c6e-4d14-ac7a-990301b62883">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29524275-3c6e-4d14-ac7a-990301b62883">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

